### PR TITLE
Makefile: Link to math lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ valgrind:
 
 make build_cli:
 	rm -f connxr
-	gcc -std=c99 -Wall -D TRACE_LEVEL=0 -o connxr src/operators/*.c src/*.c src/pb/onnx.pb-c.c src/pb/protobuf-c.c
+	gcc -std=c99 -Wall -D TRACE_LEVEL=0 -o connxr src/operators/*.c src/*.c src/pb/onnx.pb-c.c src/pb/protobuf-c.c -lm
 
 #memory leak stuff TODO:
 


### PR DESCRIPTION
Hi,
I think the "-lm" should be added in order to use the math lib functions (sqrtf etc).

ps. I only ran the "make build_cli", could not ran "make build" yet because I'm currently missing the cunit framework