### PR TITLE
Compile with -Werror

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ ALL+=runtest
 TARGET+=runtest
 runtest: $(BUILDDIR)/runtest
 $(BUILDDIR)/runtest: $(OBJS)
-	$(CC) -o $@ src/test/tests.c $^ $(CPPFLAGS) $(LDFLAGS) $(LDLIBS)
+	$(CC) -o $@ src/test/tests.c $^ $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(LDLIBS)
 
 .phony: clean_build
 CLEAN+=clean_build
@@ -199,7 +199,7 @@ TARGET+=connxr
 ALL+=connxr
 connxr: $(BUILDDIR)/connxr
 $(BUILDDIR)/connxr: $(OBJS)
-	$(CC) -o $@ src/connxr.c $^ $(CPPFLAGS) $(LDFLAGS) $(LDLIBS)
+	$(CC) -o $@ src/connxr.c $^ $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(LDLIBS)
 
 define PROFILING_MODEL
 HELP_profiling_$(1)=run $(1) profiling

--- a/include/test/models/common_models.h
+++ b/include/test/models/common_models.h
@@ -62,14 +62,14 @@ void test_model(
 
   resolve(model, inputs, 1);
   start = clock();
-  Onnx__TensorProto **output = inference(model, inputs, 1);
+  inference(model, inputs, 1);
   end = clock();
 
   cpu_time_used = ((double) (end - start)) / CLOCKS_PER_SEC;
 
   printf("[benchmark][%s] cycles: %f\n", model_id, (double) (end - start));
   printf("[benchmark][%s] cpu_time_used: %f\n", model_id, cpu_time_used);
-  printf("[benchmark][%s] CLOCKS_PER_SEC: %d\n", model_id, CLOCKS_PER_SEC);
+  printf("[benchmark][%s] CLOCKS_PER_SEC: %lld\n", model_id, (long long int)CLOCKS_PER_SEC);
 
   //Asserts the result using the last calculated output.
   printf("Will compare output %d = %s", _populatedIdx, all_context[_populatedIdx].outputs[0]->name);

--- a/include/test/test_utils.h
+++ b/include/test/test_utils.h
@@ -165,7 +165,7 @@ void testOperator(char *outputName)
 
   resolve(model, inputs, nInputs);
   printf("Running inference\n");
-  Onnx__TensorProto **output = inference(model, inputs, nInputs);
+  inference(model, inputs, nInputs);
 
   /* Some operators have more than two outputs to assert */
   printf("Will compare output %d = %s", _populatedIdx, all_context[_populatedIdx].outputs[0]->name);

--- a/src/connxr.c
+++ b/src/connxr.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -42,7 +43,7 @@ int main(int argc, char **argv){
     resolve(model, inputs, 1);
     printf("Running inference on %s model...\n", model->graph->name);
     start = clock();
-    Onnx__TensorProto **output = inference(model, inputs, 1);
+    inference(model, inputs, 1);
     end = clock();
     printf("finished!\n");
 
@@ -63,7 +64,7 @@ int main(int argc, char **argv){
         fprintf(fp, "name=%s\n", all_context[i].outputs[0]->name);
         fprintf(fp, "shape=");
         for (int dim_index = 0; dim_index < all_context[i].outputs[0]->n_dims; dim_index++){
-          fprintf(fp, "%lld,", all_context[i].outputs[0]->dims[dim_index]);
+          fprintf(fp, "%" PRId64 ",", all_context[i].outputs[0]->dims[dim_index]);
         }
         fprintf(fp, "\n");
         //int float_to_print = all_context[i].outputs[0]->n_float_data > max_print ? max_print : all_context[i].outputs[0]->n_float_data;


### PR DESCRIPTION
This is just a quick "get to know cONNXr"-commit. No functional changes.

Use CFLAGS when compiling connxr & runtest.
Fix compiler warnings: unused variables and print format errors.