### PR TITLE
enum defined before typedef to ensure compatibility with c++

### DIFF
--- a/include/operators/operator.h
+++ b/include/operators/operator.h
@@ -4,31 +4,29 @@
 #include "onnx.pb-c.h"
 #include <errno.h>
 
+enum operator_status {
+  OP_OK = 0,
+  OP_ENOSYS = ENOSYS, // Function not implemented
+  OP_ENOMEM = ENOMEM, // Out of memory
+  OP_EINVAL = EINVAL, // Invalid argument
+  OP_EDOM = EDOM,     // Math argument out of domain of func
+  OP_ERANGE = ERANGE  // Math result not representable
+};
+
 // TODO Remove unused code
 typedef enum operator_status operator_status;
-typedef struct node_context  node_context;
+typedef struct node_context node_context;
 typedef operator_status (*operator_preparer)(node_context *ctx);
 typedef operator_status (*operator_executer)(node_context *ctx);
 typedef operator_executer (*operator_resolver)(node_context *ctx);
 
-
-
 // TODO Move this to a file named operator_interface
 struct node_context {
-  Onnx__NodeProto     *onnx_node;
-  Onnx__TensorProto  **inputs;
-  Onnx__TensorProto  **outputs;
-  operator_executer    executer;
-  void                *executer_context;
-};
-
-enum operator_status {
-  OP_OK     = 0,
-  OP_ENOSYS = ENOSYS, // Function not implemented
-  OP_ENOMEM = ENOMEM, // Out of memory
-  OP_EINVAL = EINVAL, // Invalid argument
-  OP_EDOM   = EDOM,   // Math argument out of domain of func
-  OP_ERANGE = ERANGE  // Math result not representable
+  Onnx__NodeProto *onnx_node;
+  Onnx__TensorProto **inputs;
+  Onnx__TensorProto **outputs;
+  operator_executer executer;
+  void *executer_context;
 };
 
 #endif


### PR DESCRIPTION
In order to ensure compatibility with C++ compiler the definition of `enum operator_status` should happen before `typedef enum operator_status operator_status`.

You can find an example in the link below:
https://riptutorial.com/c/example/6564/typedef-enum